### PR TITLE
Fix: Resolve horizontal overflow and improve content centering

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -18,7 +18,7 @@ body {
 }
 
 .prose {
-  max-width: fit-content !important;
+  max-width: 100%;
 }
 
 .prose .anchor {
@@ -49,6 +49,7 @@ body {
 
 .prose pre {
   @apply border border-neutral-800 bg-neutral-900;
+  overflow-x: auto;
 }
 
 .prose code {
@@ -63,6 +64,8 @@ body {
 .prose img {
   /* Don't apply styles to next/image */
   @apply m-0;
+  max-width: 100%;
+  height: auto;
 }
 
 .prose > :first-child {


### PR DESCRIPTION
This commit addresses issues where a horizontal scrollbar would appear on various pages and content was not always reliably centered.

The primary changes include:

1.  Modified the `.prose` class in `src/app/global.css` to use `max-width: 100%;` instead of `max-width: fit-content !important;`. This prevents markdown content (which uses the `.prose` class) from expanding beyond its parent container, which was the main cause of the page-level horizontal scrollbar.

2.  Added `overflow-x: auto;` to `.prose pre` styles. This ensures that code blocks within prose sections will scroll horizontally if their content is too wide, rather than causing the entire page to scroll.

3.  Added `max-width: 100%;` and `height: auto;` to `.prose img` styles. This makes any standard `<img>` tags used within prose content responsive, preventing them from overflowing their containers.

The overall page layout defined in `src/app/layout.tsx` (using `max-w-4xl` and `lg:mx-auto`) was confirmed to be suitable for constraining width and centering the main content block. The implemented changes ensure that components within this block, particularly those styled by `.prose`, respect these boundaries.