### PR TITLE
Fix: Ensure tables in prose do not cause page overflow

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -110,6 +110,10 @@ table {
   white-space: nowrap;
 }
 
+.prose table {
+  width: 100%;
+}
+
 .prose .callout > p {
   margin: 0 !important;
 }


### PR DESCRIPTION
This commit addresses a persistent horizontal scrollbar issue, specifically observed on pages with wide tables within the .prose styled content (e.g., /posts/browser-module-tech).

The previous fix attempt correctly constrained .prose elements and handled images and code blocks, but wide tables could still cause page overflow.

The specific change is:
- Added `.prose table { width: 100%; }` to `src/app/global.css`.

This rule overrides the global `table { max-width: fit-content; }` for tables nested within .prose containers. It forces the table element to occupy the full width of its .prose parent, preventing the table itself from expanding the page. The table's internal content will still scroll horizontally if it exceeds this width, due to inherited `overflow-x: auto` and `white-space: nowrap` properties from the global table style.

This ensures that wide tables are properly contained and scrollable internally without causing page-level horizontal scrollbars.