### PR TITLE
Enhance sitemap SEO for Knowledge artifacts

### DIFF
--- a/src/app/knowledge/_lib/artifacts.ts
+++ b/src/app/knowledge/_lib/artifacts.ts
@@ -59,12 +59,30 @@ export function getArtifactsWithMeta(): ArtifactEntry[] {
       slug,
       key,
       meta: metadata[key] ?? {
-        title: slug[slug.length - 1].replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+        title: slug[slug.length - 1]
+          .replace(/-/g, ' ')
+          .replace(/\b\w/g, (c) => c.toUpperCase()),
         emojiIcon: '📄',
-        desc: '',
-      },
+        desc: ''
+      }
     }
   })
+}
+
+export function getArtifactLastModified(slug: string[]): string {
+  const artifact = resolveArtifact(slug)
+  const metaPath = path.join(ARTIFACTS_DIR, 'metadata.json')
+
+  const timestamps: number[] = []
+  if (artifact && fs.existsSync(artifact.filePath)) {
+    timestamps.push(fs.statSync(artifact.filePath).mtimeMs)
+  }
+  if (fs.existsSync(metaPath)) {
+    timestamps.push(fs.statSync(metaPath).mtimeMs)
+  }
+
+  const latest = timestamps.length > 0 ? Math.max(...timestamps) : Date.now()
+  return new Date(latest).toISOString()
 }
 
 export function resolveArtifact(

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,61 +1,102 @@
-import { allBlogs } from 'contentlayer/generated';
-import { quotes } from '@/data/quotes';
-import { getArtifactsWithMeta } from './knowledge/_lib/artifacts';
+import type { MetadataRoute } from 'next'
+import { allBlogs } from 'contentlayer/generated'
+import { quotes } from '@/data/quotes'
+import {
+  getArtifactLastModified,
+  getArtifactsWithMeta
+} from './knowledge/_lib/artifacts'
 
-export default async function sitemap() {
+const SITE_URL = 'https://arno.surfacew.com'
+
+function withSiteUrl(pathname: string): string {
+  return `${SITE_URL}${pathname}`
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const todayIso = new Date().toISOString()
+
   const blogs = allBlogs.map((post) => ({
-    url: `https://arno.surfacew.com/posts/${post.slug}`,
+    url: withSiteUrl(`/posts/${post.slug}`),
     lastModified: post.publishedAt,
-  }));
+    changeFrequency: 'monthly' as const,
+    priority: 0.8
+  }))
 
   const quotePages = quotes.map((quote) => ({
-    url: `https://arno.surfacew.com/quotes/${quote.id}`,
-    lastModified: quote.date || new Date().toISOString().split('T')[0],
-  }));
+    url: withSiteUrl(`/quotes/${quote.id}`),
+    lastModified: quote.date || todayIso,
+    changeFrequency: 'yearly' as const,
+    priority: 0.5
+  }))
 
-  const routes = ['', '/posts/topics', '/rss', '/idea', '/about', '/quotes', '/knowledge', '/knowledge/playground'].map(
-    (route) => ({
-      url: `https://arno.surfacew.com${route}`,
-      lastModified: new Date().toISOString().split('T')[0],
-    })
-  );
+  const routes = [
+    '',
+    '/posts/topics',
+    '/rss',
+    '/idea',
+    '/about',
+    '/quotes',
+    '/knowledge',
+    '/knowledge/playground'
+  ].map((route) => ({
+    url: withSiteUrl(route),
+    lastModified: todayIso,
+    changeFrequency:
+      route === '/knowledge' ? ('weekly' as const) : ('monthly' as const),
+    priority: route === '' ? 1 : route === '/knowledge' ? 0.9 : 0.6
+  }))
 
   const knowledgeArtifacts = getArtifactsWithMeta().map((artifact) => ({
-    url: `https://arno.surfacew.com/knowledge/${artifact.key}`,
-    lastModified: new Date().toISOString().split('T')[0],
-  }));
+    url: withSiteUrl(`/knowledge/${artifact.key}`),
+    lastModified: getArtifactLastModified(artifact.slug),
+    changeFrequency: 'monthly' as const,
+    priority: artifact.meta.desc ? 0.85 : 0.75
+  }))
 
-  const languageTags = new Set<string>();
-  const contentTags = new Set<string>();
+  const languageTags = new Set<string>()
+  const contentTags = new Set<string>()
 
-  allBlogs.forEach(post => {
+  allBlogs.forEach((post) => {
     if (post.tags && Array.isArray(post.tags)) {
-      post.tags.forEach(tag => {
+      post.tags.forEach((tag) => {
         if (tag === 'en' || tag === 'zh') {
-          languageTags.add(tag);
+          languageTags.add(tag)
         } else {
-          contentTags.add(tag);
+          contentTags.add(tag)
         }
-      });
+      })
     }
-  });
+  })
 
-  const tagLangRoutes = [];
-  contentTags.forEach(tag => {
-    languageTags.forEach(lang => {
-      const relevantPosts = allBlogs.filter(post =>
-        post.tags && post.tags.includes(tag) && post.tags.includes(lang)
-      );
+  const tagLangRoutes = []
+  contentTags.forEach((tag) => {
+    languageTags.forEach((lang) => {
+      const relevantPosts = allBlogs.filter(
+        (post) =>
+          post.tags && post.tags.includes(tag) && post.tags.includes(lang)
+      )
 
       if (relevantPosts.length > 0) {
-        relevantPosts.sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
+        relevantPosts.sort(
+          (a, b) =>
+            new Date(b.publishedAt).getTime() -
+            new Date(a.publishedAt).getTime()
+        )
         tagLangRoutes.push({
-          url: `https://arno.surfacew.com/posts/topics/${tag}/${lang}`,
+          url: withSiteUrl(`/posts/topics/${tag}/${lang}`),
           lastModified: relevantPosts[0].publishedAt,
-        });
+          changeFrequency: 'weekly' as const,
+          priority: 0.7
+        })
       }
-    });
-  });
+    })
+  })
 
-  return [...routes, ...blogs, ...quotePages, ...tagLangRoutes, ...knowledgeArtifacts];
+  return [
+    ...routes,
+    ...blogs,
+    ...quotePages,
+    ...tagLangRoutes,
+    ...knowledgeArtifacts
+  ]
 }


### PR DESCRIPTION
### Motivation
- Ensure the Knowledge module (artifacts) is fully represented in the sitemap and surface accurate freshness signals so search engines can better crawl and index artifact pages.
- Use artifact metadata already provided in `artifacts/metadata.json` to improve SEO signals (descriptions, last-modified) for knowledge pages.

### Description
- Added `getArtifactLastModified(slug: string[])` in `src/app/knowledge/_lib/artifacts.ts` to compute a robust `lastModified` by comparing the artifact file mtime and the `artifacts/metadata.json` mtime.
- Updated `src/app/sitemap.ts` to return a typed `MetadataRoute.Sitemap`, centralize absolute URL creation with `SITE_URL` + `withSiteUrl`, and include sitemap hints (`changeFrequency`, `priority`) for routes, blog posts, quotes, topic-language listing pages, and knowledge artifacts.
- Knowledge artifact entries now use `getArtifactLastModified(...)` for `lastModified` and tune `priority` based on presence of artifact description, while topic-language routes receive `changeFrequency` and `priority` signals.

### Testing
- Ran `pnpm exec prettier --write src/app/sitemap.ts src/app/knowledge/_lib/artifacts.ts` which completed successfully.
- Ran `pnpm build` which completed and generated static pages; non-fatal `esbuild` fetch/import warnings related to the playground transform appeared during static generation but did not block the build.
- Ran `pnpm exec tsc --noEmit` which failed due to existing repository-wide typing issues unrelated to these changes (e.g. missing `contentlayer/generated` types and other unrelated type errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1aeac053083308982e8fede8a26a4)