### PR TITLE
Add canonical alternates to page metadata and generate tag page metadata; update sitemap

### DIFF
--- a/src/app/knowledge/[...slug]/page.tsx
+++ b/src/app/knowledge/[...slug]/page.tsx
@@ -25,6 +25,9 @@ export function generateMetadata({
   return {
     title,
     description,
+    alternates: {
+      canonical: `/knowledge/${key}`,
+    },
     openGraph: {
       title: `${title} | Knowledge | Arno`,
       description,

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -5,6 +5,9 @@ import { getArtifactsWithMeta } from './_lib/artifacts'
 export const metadata: Metadata = {
   title: 'Knowledge',
   description: "Arno's interactive knowledge base — visual guides, demos, and living documents built with HTML and JSX.",
+  alternates: {
+    canonical: '/knowledge',
+  },
   openGraph: {
     title: 'Knowledge | Arno',
     description: 'Interactive knowledge base — visual guides, demos, and living documents.',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,6 +19,9 @@ export async function generateMetadata(): Promise<Metadata> {
     title,
     description,
     keywords,
+    alternates: {
+      canonical: '/',
+    },
     openGraph: {
       title,
       description,

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -29,6 +29,9 @@ export async function generateMetadata({
     title,
     description,
     keywords: tags,
+    alternates: {
+      canonical: `/posts/${slug}`,
+    },
     openGraph: {
       title,
       description,

--- a/src/app/posts/topics/page.tsx
+++ b/src/app/posts/topics/page.tsx
@@ -5,7 +5,10 @@ import { NextResponse } from 'next/server'
 
 export const metadata: Metadata = {
   title: 'Blog',
-  description: 'Read my thoughts on software development, design, and more.'
+  description: 'Read my thoughts on software development, design, and more.',
+  alternates: {
+    canonical: '/posts/topics',
+  },
 }
 
 export default async function PostPageServer({

--- a/src/app/posts/topics/tag/[tag]/page.tsx
+++ b/src/app/posts/topics/tag/[tag]/page.tsx
@@ -1,10 +1,27 @@
 import type { Metadata } from 'next';
 import { PostListServer } from '@/components/posts/post-list';
 
-export const metadata: Metadata = {
-  title: 'Blog',
-  description: 'Read my thoughts on software development, design, and more.',
-};
+export function generateMetadata({ params }: {
+  params: {
+    tag?: string;
+  }
+}): Metadata {
+  const decodedTag = params.tag ? decodeURIComponent(params.tag) : undefined;
+  const title = decodedTag ? `Blog: ${decodedTag}` : 'Blog';
+  const description = decodedTag
+    ? `Read posts tagged "${decodedTag}" on software development, design, and more.`
+    : 'Read my thoughts on software development, design, and more.';
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: decodedTag
+        ? `/posts/topics/tag/${encodeURIComponent(decodedTag)}`
+        : '/posts/topics',
+    },
+  };
+}
 
 export default async function PostsListPageByTagServer({ params }: {
   params: {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -26,7 +26,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     '/posts/topics',
     '/rss',
     '/idea',
-    '/about',
     '/knowledge',
     '/knowledge/playground'
   ].map((route) => ({


### PR DESCRIPTION
### Motivation
- Ensure each page exposes a canonical URL in metadata for better SEO and link discovery.
- Provide correct dynamic metadata for tag-filtered blog pages so titles, descriptions, and canonicals reflect the selected tag.
- Keep the sitemap in sync with current site routes.

### Description
- Added `alternates.canonical` entries to metadata for the root page (`/`), knowledge index (`/knowledge`), knowledge artifact pages (`/knowledge/[...slug]`), blog index (`/posts/topics`), and individual blog posts (`/posts/[slug]`).
- Implemented `generateMetadata` for the tag list page at `posts/topics/tag/[tag]/page.tsx` to decode the tag, produce a contextual title and description, and set a canonical URL using `encodeURIComponent` for the tag path.
- Removed the `/about` route from the sitemap generation so the sitemap only includes active site routes.

### Testing
- Ran `next build` to validate Next.js build output, which completed successfully.
- Ran TypeScript checks with `tsc --noEmit`, which passed without type errors.
- Ran `npm run lint` to validate code style, which returned no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2485aa2208330b0b7726dcfba6b8d)