### PR TITLE
feat: add table-of-contents outline to blog posts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -204,7 +204,13 @@ Find post by slug → render MDX → ship cached HTML
 
 Why: build-time generation means a post is free to serve and indexed cleanly.
 Contentlayer's `structuredData` computed field is what gives each post its
-schema.org BlogPosting payload.
+schema.org BlogPosting payload. A sibling `headings` computed field extracts
+the post's h2/h3 outline at build time — slugs are produced with the same
+`github-slugger` that `rehype-slug` uses, so the table-of-contents anchors
+match the rendered heading ids exactly. The `Toc` client component
+(`src/components/toc.tsx`) renders that outline in the left gutter on wide
+screens with IntersectionObserver scroll-spy; it ships zero extra build cost
+and degrades to nothing on narrow viewports.
 
 ### Render a knowledge artifact
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ optional — log them when they change how a contributor works.
 ## [Unreleased]
 
 ### Added
+- Post outlines — a sticky "On this page" table of contents on `/posts/[slug]`.
+  Headings are extracted at build time (Contentlayer `headings` field, slugs
+  matching `rehype-slug`) and rendered in the left gutter on wide screens with
+  scroll-spy and smooth-scroll.
 - `DEPLOYMENT.md` — formal deploy contract for Vercel.
 - `ARCHITECTURE.md` — system blueprint for the portfolio + knowledge artifacts.
 - `VERSION` + this `CHANGELOG.md` — release discipline scaffolding.

--- a/contentlayer.config.js
+++ b/contentlayer.config.js
@@ -3,9 +3,62 @@ import remarkGfm from 'remark-gfm'
 import rehypePrettyCode from 'rehype-pretty-code'
 import rehypeSlug from 'rehype-slug'
 import rehypeAutolinkHeadings from 'rehype-autolink-headings'
+import GithubSlugger from 'github-slugger'
+
+// Strip inline markdown so heading text reads cleanly in the outline.
+function stripInlineMarkdown(text) {
+  return text
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1') // images → alt
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // links → label
+    .replace(/`([^`]+)`/g, '$1') // inline code
+    .replace(/(\*\*|__)(.*?)\1/g, '$2') // bold
+    .replace(/(\*|_)(.*?)\1/g, '$2') // italic
+    .replace(/~~(.*?)~~/g, '$1') // strikethrough
+    .trim()
+}
+
+// Extract h2/h3 headings with slugs that match rehype-slug's generated ids.
+// Every heading (h1–h6) is fed through one slugger in document order so the
+// dedupe counter advances identically to rehype-slug.
+function extractHeadings(raw) {
+  const slugger = new GithubSlugger()
+  const headings = []
+  let inFence = false
+  let fenceMarker = ''
+
+  for (const line of raw.split('\n')) {
+    const fence = line.match(/^\s*(```|~~~)/)
+    if (fence) {
+      if (!inFence) {
+        inFence = true
+        fenceMarker = fence[1]
+      } else if (line.trimStart().startsWith(fenceMarker)) {
+        inFence = false
+      }
+      continue
+    }
+    if (inFence) continue
+
+    const match = line.match(/^(#{1,6})\s+(.+?)\s*#*$/)
+    if (!match) continue
+
+    const level = match[1].length
+    const text = stripInlineMarkdown(match[2])
+    const slug = slugger.slug(text)
+    if (level >= 2 && level <= 3) {
+      headings.push({ level, text, slug })
+    }
+  }
+
+  return headings
+}
 
 /** @type {import('contentlayer/source-files').ComputedFields} */
 const computedFields = {
+  headings: {
+    type: 'json',
+    resolve: (doc) => extractHeadings(doc.body.raw)
+  },
   slug: {
     type: 'string',
     resolve: (doc) => doc._raw.flattenedPath

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dotenv": "^16.6.1",
     "esbuild-wasm": "^0.27.4",
     "framer-motion": "^10.18.0",
+    "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
     "next": "13.5.5",
     "next-contentlayer": "^0.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       framer-motion:
         specifier: ^10.18.0
         version: 10.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -5350,7 +5353,7 @@ snapshots:
       eslint: 8.46.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@8.46.0))(eslint@8.46.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.46.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.46.0)
       eslint-plugin-react: 7.37.5(eslint@8.46.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.46.0)
@@ -5380,7 +5383,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.46.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5395,7 +5398,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.46.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.46.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.46.0))(eslint@8.46.0))(eslint@8.46.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { Mdx } from '@/components/mdx'
+import { Toc, type Heading } from '@/components/toc'
 import { UVCardEDots } from '@/components/uv-card/uv-card'
 import { allBlogs } from 'contentlayer/generated'
 import type { Metadata } from 'next'
@@ -130,6 +131,7 @@ export default async function BlogPost({ params }) {
           __html: JSON.stringify(breadcrumbData)
         }}
       ></script>
+      <Toc headings={post.headings as Heading[]} />
       <h1 className="font-bold text-2xl tracking-tighter">
         <Balancer>{post.title}</Balancer>
       </h1>

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import clsx from 'clsx'
+import { useEffect, useState } from 'react'
+
+export type Heading = {
+  level: number
+  text: string
+  slug: string
+}
+
+export function Toc({ headings }: { headings: Heading[] }) {
+  const [activeId, setActiveId] = useState<string>('')
+
+  useEffect(() => {
+    if (headings.length === 0) return
+
+    const elements = headings
+      .map((h) => document.getElementById(h.slug))
+      .filter((el): el is HTMLElement => el !== null)
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id)
+        }
+      },
+      { rootMargin: '0px 0px -70% 0px', threshold: 1 }
+    )
+
+    elements.forEach((el) => observer.observe(el))
+    return () => observer.disconnect()
+  }, [headings])
+
+  const handleClick = (event: React.MouseEvent, slug: string) => {
+    event.preventDefault()
+    const el = document.getElementById(slug)
+    if (!el) return
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    history.replaceState(null, '', `#${slug}`)
+    setActiveId(slug)
+  }
+
+  if (headings.length === 0) return null
+
+  return (
+    <nav
+      aria-label="Table of contents"
+      className="hidden xl:block fixed top-32 w-40 max-h-[70vh] overflow-y-auto left-[max(1rem,calc(50%-39.5rem))]"
+    >
+      <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-neutral-400 dark:text-neutral-500">
+        On this page
+      </p>
+      <ul className="space-y-2 text-sm border-l border-neutral-200 dark:border-neutral-800">
+        {headings.map((heading) => {
+          const isActive = activeId === heading.slug
+          return (
+            <li key={heading.slug}>
+              <a
+                href={`#${heading.slug}`}
+                onClick={(event) => handleClick(event, heading.slug)}
+                className={clsx(
+                  '-ml-px block border-l py-0.5 leading-snug transition-colors',
+                  isActive
+                    ? 'border-neutral-900 text-neutral-900 dark:border-neutral-100 dark:text-neutral-100'
+                    : 'border-transparent text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200'
+                )}
+                style={{ paddingLeft: `${(heading.level - 2) * 0.75 + 0.75}rem` }}
+              >
+                {heading.text}
+              </a>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds a sticky **"On this page"** table of contents to `/posts/[slug]`, shown in the left gutter on wide screens.
- Headings (h2/h3) are extracted at **build time** via a new Contentlayer `headings` computed field, using the same `github-slugger` as `rehype-slug` so TOC anchors match rendered heading ids exactly — zero extra runtime/build cost.
- New `Toc` client component (`src/components/toc.tsx`) with IntersectionObserver scroll-spy and smooth-scroll; gracefully renders nothing on narrow viewports and on posts without headings.

## Implementation notes
- `contentlayer.config.js`: `extractHeadings()` walks the raw MDX, skips fenced code blocks, strips inline markdown, and feeds every heading (h1–h6) through one slugger in document order to mirror `rehype-slug`'s dedupe, keeping h2/h3 for the outline.
- Positioned with `left-[max(1rem,calc(50%-39.5rem))]` so it sits in the centered layout's left gutter without overlapping content; `hidden xl:block`.
- Docs synced: `ARCHITECTURE.md` (blog flow) and `CHANGELOG.md` (Unreleased / Added).

## Test plan
- [x] `pnpm build` passes (34 pages generated).
- [x] Generated `headings` slugs match live rendered heading `id`s (verified for `ai-product-enginner` + spot-checked other posts).
- [x] TOC markup verified live: 30 items, h2 at `0.75rem` / h3 indented `1.5rem`, hrefs are heading anchors.
- [ ] Visual scroll-spy / smooth-scroll confirmation on a wide viewport (browser screenshot tooling was timing out locally — worth a quick manual check on the preview deploy).

Note: no automated test framework in this repo; verification is build + render inspection.

Made with [Cursor](https://cursor.com)