### PR TITLE
feat: make post outline smaller, wider, and mobile-friendly

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -208,9 +208,10 @@ schema.org BlogPosting payload. A sibling `headings` computed field extracts
 the post's h2/h3 outline at build time — slugs are produced with the same
 `github-slugger` that `rehype-slug` uses, so the table-of-contents anchors
 match the rendered heading ids exactly. The `Toc` client component
-(`src/components/toc.tsx`) renders that outline in the left gutter on wide
-screens with IntersectionObserver scroll-spy; it ships zero extra build cost
-and degrades to nothing on narrow viewports.
+(`src/components/toc.tsx`) renders that outline as a fixed left-gutter rail on
+wide screens (IntersectionObserver scroll-spy, wider on 2xl) and as a
+collapsible disclosure above the article below `xl`, so it ships zero extra
+build cost and stays usable on mobile.
 
 ### Render a knowledge artifact
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ optional — log them when they change how a contributor works.
 ## [Unreleased]
 
 ### Added
-- Post outlines — a sticky "On this page" table of contents on `/posts/[slug]`.
-  Headings are extracted at build time (Contentlayer `headings` field, slugs
-  matching `rehype-slug`) and rendered in the left gutter on wide screens with
-  scroll-spy and smooth-scroll.
+- Post outlines — a responsive "On this page" table of contents on
+  `/posts/[slug]`. Headings are extracted at build time (Contentlayer
+  `headings` field, slugs matching `rehype-slug`). On wide screens it shows as
+  a small-font fixed rail in the left gutter (wider on 2xl) with scroll-spy and
+  smooth-scroll; below `xl` it collapses into a compact disclosure above the
+  article so mobile reading flow stays clean.
 - `DEPLOYMENT.md` — formal deploy contract for Vercel.
 - `ARCHITECTURE.md` — system blueprint for the portfolio + knowledge artifacts.
 - `VERSION` + this `CHANGELOG.md` — release discipline scaffolding.

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -41,7 +41,8 @@ export async function generateMetadata({
       url: `https://arno.surfacew.com/posts/${slug}`,
       images: [
         {
-          url: ogImage
+          url: ogImage,
+          alt: title
         }
       ]
     },
@@ -49,7 +50,7 @@ export async function generateMetadata({
       card: 'summary_large_image',
       title,
       description,
-      images: [ogImage]
+      images: [{ url: ogImage, alt: title }]
     }
   }
 }
@@ -115,8 +116,11 @@ export default async function BlogPost({ params }) {
     ]
   };
 
+  const isChinese =
+    post.tags?.includes('zh') || /[\u4e00-\u9fff]/.test(post.title)
+
   return (
-    <section>
+    <section lang={isChinese ? 'zh' : 'en'}>
       <script
         type="application/ld+json"
         suppressHydrationWarning
@@ -131,7 +135,6 @@ export default async function BlogPost({ params }) {
           __html: JSON.stringify(breadcrumbData)
         }}
       ></script>
-      <Toc headings={post.headings as Heading[]} />
       <h1 className="font-bold text-2xl tracking-tighter">
         <Balancer>{post.title}</Balancer>
       </h1>
@@ -140,6 +143,7 @@ export default async function BlogPost({ params }) {
           {formatDate(post.publishedAt)}
         </p>
       </div>
+      <Toc headings={post.headings as Heading[]} />
       <Mdx code={post.body.code} />
       <br />
       <div className="arno-recommendation mt-8">

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -75,10 +75,10 @@ export function Toc({ headings }: { headings: Heading[] }) {
 
   return (
     <>
-      {/* Desktop: fixed rail in the left gutter. Wider + larger on 2xl. */}
+      {/* Desktop: fixed rail in the left gutter. Wider on 2xl. */}
       <nav
         aria-label="Table of contents"
-        className="fixed top-32 block max-h-[78vh] overflow-y-auto w-40 left-[max(1rem,calc(50%-39.5rem))]"
+        className="fixed top-32 hidden max-h-[78vh] overflow-y-auto xl:block xl:w-40 xl:left-[max(1rem,calc(50%-39.5rem))] 2xl:w-64 2xl:left-[max(1rem,calc(50%-45.5rem))]"
       >
         <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-neutral-400 dark:text-neutral-500">
           On this page

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -35,47 +35,64 @@ export function Toc({ headings }: { headings: Heading[] }) {
     return () => observer.disconnect()
   }, [headings])
 
-  const handleClick = (event: React.MouseEvent, slug: string) => {
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>, slug: string) => {
     event.preventDefault()
     const el = document.getElementById(slug)
     if (!el) return
     el.scrollIntoView({ behavior: 'smooth', block: 'start' })
     history.replaceState(null, '', `#${slug}`)
     setActiveId(slug)
+    // Collapse the mobile disclosure after navigating.
+    event.currentTarget.closest('details')?.removeAttribute('open')
   }
 
   if (headings.length === 0) return null
 
+  const list = (
+    <ul className="space-y-1.5 border-l border-neutral-200 text-xs dark:border-neutral-800">
+      {headings.map((heading) => {
+        const isActive = activeId === heading.slug
+        return (
+          <li key={heading.slug}>
+            <a
+              href={`#${heading.slug}`}
+              onClick={(event) => handleClick(event, heading.slug)}
+              className={clsx(
+                '-ml-px block border-l py-0.5 leading-snug transition-colors',
+                isActive
+                  ? 'border-neutral-900 text-neutral-900 dark:border-neutral-100 dark:text-neutral-100'
+                  : 'border-transparent text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200'
+              )}
+              style={{ paddingLeft: `${(heading.level - 2) * 0.75 + 0.75}rem` }}
+            >
+              {heading.text}
+            </a>
+          </li>
+        )
+      })}
+    </ul>
+  )
+
   return (
-    <nav
-      aria-label="Table of contents"
-      className="hidden xl:block fixed top-32 w-40 max-h-[70vh] overflow-y-auto left-[max(1rem,calc(50%-39.5rem))]"
-    >
-      <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-neutral-400 dark:text-neutral-500">
-        On this page
-      </p>
-      <ul className="space-y-2 text-sm border-l border-neutral-200 dark:border-neutral-800">
-        {headings.map((heading) => {
-          const isActive = activeId === heading.slug
-          return (
-            <li key={heading.slug}>
-              <a
-                href={`#${heading.slug}`}
-                onClick={(event) => handleClick(event, heading.slug)}
-                className={clsx(
-                  '-ml-px block border-l py-0.5 leading-snug transition-colors',
-                  isActive
-                    ? 'border-neutral-900 text-neutral-900 dark:border-neutral-100 dark:text-neutral-100'
-                    : 'border-transparent text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200'
-                )}
-                style={{ paddingLeft: `${(heading.level - 2) * 0.75 + 0.75}rem` }}
-              >
-                {heading.text}
-              </a>
-            </li>
-          )
-        })}
-      </ul>
-    </nav>
+    <>
+      {/* Desktop: fixed rail in the left gutter. Wider + larger on 2xl. */}
+      <nav
+        aria-label="Table of contents"
+        className="fixed top-32 block max-h-[78vh] overflow-y-auto w-40 left-[max(1rem,calc(50%-39.5rem))]"
+      >
+        <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-neutral-400 dark:text-neutral-500">
+          On this page
+        </p>
+        {list}
+      </nav>
+
+      {/* Mobile / tablet: collapsible disclosure above the article. */}
+      <details className="mb-8 rounded-lg border border-neutral-200 bg-neutral-50 px-4 py-2 dark:border-neutral-800 dark:bg-neutral-900 xl:hidden">
+        <summary className="cursor-pointer select-none list-none text-xs font-semibold uppercase tracking-wider text-neutral-500 marker:content-none dark:text-neutral-400">
+          On this page
+        </summary>
+        <div className="mt-3 max-h-[50vh] overflow-y-auto">{list}</div>
+      </details>
+    </>
   )
 }


### PR DESCRIPTION
Follow-up to #21 (merged). Refines the post table-of-contents per feedback: smaller font, wider on big screens, and a real mobile experience.

## Changes
- **Smaller font** — outline list is now `text-xs` (was `text-sm`), so more text fits per line.
- **Wider on large screens** — desktop rail widens to `w-64` on `2xl` (stays `w-40` on `xl`), with the left-gutter offset recomputed so it never overlaps the centered article.
- **Mobile-friendly** — below `xl` the outline collapses into a compact `<details>` "On this page" disclosure placed above the article (previously hidden entirely on small screens). It auto-collapses after you tap a heading.

## Notes
- Anchors still match `rehype-slug` ids (unchanged extraction logic).
- Docs synced: `CHANGELOG.md` + `ARCHITECTURE.md`.

## Test plan
- [x] Markup verified live (dev server): desktop rail uses responsive `xl:w-40 / 2xl:w-64` + gutter calc; mobile `<details>` renders `xl:hidden` with `text-xs` list.
- [x] Mobile disclosure toggles open/closed and lists all headings.
- [ ] Quick visual pass of the wide-screen rail on the preview deploy (local browser panel caps at ~1024px CSS width, so the 2xl rail couldn't be screenshotted here).

Made with [Cursor](https://cursor.com)