### PR TITLE
fix(posts): remove duplicate table-of-contents outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ optional — log them when they change how a contributor works.
 - `VERSION` + this `CHANGELOG.md` — release discipline scaffolding.
 
 ### Fixed
+- Post outline rendered twice on `/posts/[slug]` — a branch merge re-introduced
+  the `<Toc>` that an earlier commit had relocated, so each page showed two
+  overlapping fixed rails on desktop and two "On this page" disclosures on
+  mobile. Removed the duplicate, keeping the single outline above the article.
 - Article pages no longer scroll horizontally. `html` now uses `overflow-x: clip`
   (a hard guarantee that's safe with the sticky sidebar and fixed TOC since
   `clip` creates no scroll container), and `.prose` wraps long unbreakable

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -135,7 +135,6 @@ export default async function BlogPost({ params }) {
           __html: JSON.stringify(breadcrumbData)
         }}
       ></script>
-      <Toc headings={post.headings as Heading[]} />
       <h1 className="font-bold text-2xl tracking-tighter">
         <Balancer>{post.title}</Balancer>
       </h1>


### PR DESCRIPTION
## Root cause
A branch merge (`87ce5ed`, merging `cursor/seo-fixes-2026-06-01`) re-introduced the `<Toc>` that commit `5476234` had relocated above the article. This left **two** `<Toc>` instances on `/posts/[slug]`.

Since each `Toc` renders **both** a desktop fixed rail and a mobile disclosure, the page showed two overlapping fixed outlines on PC (garbled overlapping text) and two "On this page" boxes on mobile.

## Fix
Removed the duplicate `<Toc>` before the `<h1>` title, keeping the single relocated outline above the article.

## Verification
- `tsc --noEmit` passes, no lint errors.
- Rendered `/posts/agentic-system-prompt` via dev server: exactly **1** desktop nav (`aria-label="Table of contents"`) and **1** mobile `<details>` disclosure (was 2 each before).

## Test plan
- [ ] Open any `/posts/[slug]` on desktop → one outline rail in the left gutter, no overlap.
- [ ] Open on mobile → one "On this page" disclosure above the article.

Made with [Cursor](https://cursor.com)