### PR TITLE
fix: show eDots article on posts list

### DIFF
--- a/content/agentic-coding-edots.mdx
+++ b/content/agentic-coding-edots.mdx
@@ -2,7 +2,7 @@
 title: '🆙 VibeCoding a Real App: How I Built eDots'
 publishedAt: '2026-06-06'
 summary: 'How I used agentic coding, Apple-native leverage, and product craft to build eDots, my first real iOS, iPadOS, and macOS app.'
-tags: ['AI', 'VibeCoding', 'iOS', 'Product', 'eDots']
+tags: ['AI', 'VibeCoding', 'iOS', 'Product', 'eDots', 'en']
 ---
 
 I wanted to test two things.

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -9,11 +9,11 @@ export type Heading = {
   slug: string
 }
 
-export function Toc({ headings }: { headings: Heading[] }) {
+export function Toc({ headings = [] }: { headings?: Heading[] }) {
   const [activeId, setActiveId] = useState<string>('')
 
   useEffect(() => {
-    if (headings.length === 0) return
+    if (!headings.length) return
 
     const elements = headings
       .map((h) => document.getElementById(h.slug))
@@ -46,7 +46,7 @@ export function Toc({ headings }: { headings: Heading[] }) {
     event.currentTarget.closest('details')?.removeAttribute('open')
   }
 
-  if (headings.length === 0) return null
+  if (!headings.length) return null
 
   const list = (
     <ul className="space-y-1.5 border-l border-neutral-200 text-xs dark:border-neutral-800">


### PR DESCRIPTION
## Summary
- Add missing `en` language tag to `agentic-coding-edots.mdx` so the post passes the `/posts/topics` i18n filter
- Harden `Toc` to accept optional/undefined `headings` during contentlayer rebuilds

## Test plan
- [x] `pnpm build` passes
- [ ] After deploy, confirm eDots article appears at top of https://arno.surfacew.com/posts/topics
- [ ] Confirm https://arno.surfacew.com/posts/agentic-coding-edots still renders with TOC


Made with [Cursor](https://cursor.com)