### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,16 @@ Built with Next.js 13 (App Router), Contentlayer, Tailwind CSS, and deployed on 
 - Keep posts bilingual-friendly (English and Chinese).
 - Preserve existing Contentlayer schema when adding new MDX fields.
 
+## Cursor Cloud specific instructions
+
+- Single Next.js 13 app, package manager is `pnpm`. Dependencies are refreshed automatically on startup.
+- Run dev: `pnpm dev` (serves `http://localhost:3000`). Build: `pnpm build` (runs Contentlayer then `next build`).
+- Lint: `pnpm exec next lint` — there is no `lint` script in `package.json`.
+- No automated test framework is configured; there are no tests to run.
+- `pnpm install` reports "Ignored build scripts" for `contentlayer`/`esbuild`/etc. This is expected and safe — Contentlayer uses `esbuild-wasm` at runtime, so build and dev work without approving those native build scripts. Do not add `pnpm approve-builds` to setup.
+- `.env` holds local-only stub values; dev and build run fine without real Vercel secrets (Blob/Edge Config features just won't have live backends).
+- Verify content changes by hitting routes directly, e.g. a new `content/<slug>.mdx` renders at `/posts/<slug>` after Contentlayer hot-reload.
+
 <!-- e-studio-agentic-rules:start -->
 ## E-Studio Managed Rules
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Sets up and verifies the development environment for this Next.js 13 blog/portfolio.

## What was done
- Installed dependencies with `pnpm install`.
- Verified lint (`pnpm exec next lint`), build (`pnpm build`, runs Contentlayer), and dev server (`pnpm dev`).
- Completed a hello-world task: authored a temporary `content/*.mdx` post and confirmed it rendered via Contentlayer at `/posts/<slug>` (test post removed before commit).
- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` with durable run/lint/build notes.

Update script for future sessions: `pnpm install`.

## Walkthrough
[blog_dev_server_mdx_render.mp4](https://cursor.com/agents/bc-1aa8074e-8072-4ca0-9a08-96385223815b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_dev_server_mdx_render.mp4)

[Rendered MDX blog post](https://cursor.com/agents/bc-1aa8074e-8072-4ca0-9a08-96385223815b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_post_rendered.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1aa8074e-8072-4ca0-9a08-96385223815b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1aa8074e-8072-4ca0-9a08-96385223815b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

